### PR TITLE
Relax types of structs

### DIFF
--- a/src/components/local_level.jl
+++ b/src/components/local_level.jl
@@ -1,7 +1,7 @@
-struct LocalLevel <: Component
-    obs::Matrix{Int64}
-    trans::Matrix{Int64}
-    trans_cov::Matrix{Float64}
+struct LocalLevel{T <: AbstractFloat} <: Component
+    obs::Matrix{T}
+    trans::Matrix{T}
+    trans_cov::Matrix{T}
 end
 
 """
@@ -9,7 +9,14 @@ end
     LocalLevel(level_scale::Real)
 
 """
-LocalLevel(level_scale=1.) = LocalLevel([1;;], [1;;], diagm([level_scale^2]))
+function LocalLevel(level_scale::T = 1) where T <: AbstractFloat
+    LocalLevel(T[1;;], T[1;;], diagm([level_scale^2]))
+end
+
+function LocalLevel(level_scale::Integer) 
+    LocalLevel(Float64(level_scale))
+end
+
 latent_size(m::LocalLevel) = size(m.obs, 2)
 observed_size(m::LocalLevel) = size(m.obs, 1)
 Base.:(==)(c1::LocalLevel, c2::LocalLevel) = all([

--- a/src/components/local_linear.jl
+++ b/src/components/local_linear.jl
@@ -1,7 +1,7 @@
-struct LocalLinear <: Component
-    obs::Matrix{Int64}
-    trans::Matrix{Int64}
-    trans_cov::Matrix{Float64}
+struct LocalLinear{T <: AbstractFloat} <: Component
+    obs::Matrix{T}
+    trans::Matrix{T}
+    trans_cov::Matrix{T}
 end
 
 """
@@ -9,8 +9,14 @@ end
     LocalLinear(level_scale::Real, slope_scale::Real)
 
 """
-LocalLinear(level_scale=1., slope_scale=1.) = LocalLinear([1 0], [1 1; 0 1], diagm([level_scale^2, slope_scale^2]))
-latent_size(m::LocalLinear) = size(m.obs, 2)
+function LocalLinear(level_scale::T = 1., slope_scale::T = 1.) where T <: AbstractFloat
+    LocalLinear(T[1 0], T[1 1; 0 1], diagm([level_scale^2, slope_scale^2]))
+end
+
+function LocalLinear(level_scale::Integer = 1, slope_scale::Integer = 1) 
+    LocalLinear(Float64(level_scale), Float64(slope_scale))
+end
+latent_size(m::LocalLinear) = size(m.ob\s, 2)
 observed_size(m::LocalLinear) = size(m.obs, 1)
 Base.:(==)(c1::LocalLinear, c2::LocalLinear) = all([
     c1.obs == c2.obs,

--- a/src/components/seasonal.jl
+++ b/src/components/seasonal.jl
@@ -1,7 +1,7 @@
-struct Seasonal <: Component
-    obs::Matrix{Int64}
-    trans::Matrix{Int64}
-    trans_cov::Matrix{Float64}
+struct Seasonal{T <: AbstractFloat}  <: Component
+    obs::Matrix{T}
+    trans::Matrix{T}
+    trans_cov::Matrix{T}
     season_length::Int64
 end
 
@@ -10,12 +10,18 @@ end
     Seasonal(num_seasons::Integer, season_length::Integer, drift_scale::Real)
 
 """
-Seasonal(num_seasons::Integer, season_length::Integer, drift_scale::Real) = begin
-    obs = Matrix(vcat(1, zeros(Int64, num_seasons-1))')
+
+function Seasonal(num_seasons::Integer, season_length::Integer, drift_scale::T) where T <: AbstractFloat
+    obs = Matrix(vcat(1, zeros(num_seasons-1))')
     trans = diagm(ones(num_seasons))[:,vcat(num_seasons, 1:num_seasons-1)]
     trans_cov = diagm(vcat(drift_scale^2, zeros(num_seasons-1)))
-    Seasonal(obs, trans, trans_cov, season_length)
+    Seasonal(T.(obs), T.(trans), T.(trans_cov), season_length)
 end
+
+function Seasonal(num_seasons::Integer, season_length::Integer, drift_scale::Integer)
+    Seasonal(num_seasons, season_length, Float64(drift_scale))
+end
+
 latent_size(m::Seasonal) = size(m.obs, 2)
 observed_size(m::Seasonal) = size(m.obs, 1)
 Base.:(==)(c1::Seasonal, c2::Seasonal) = all([


### PR DESCRIPTION
Use `AbstractFloat` for struct  types and include constructors to promote integer arguments for convenience 