### PR TITLE
Type stable component

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,3 +11,4 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 GaussianDistributions = "0.5"
 julia = "1.7"
+StaticArrays = "1"

--- a/src/components/component.jl
+++ b/src/components/component.jl
@@ -1,6 +1,4 @@
-abstract type Component{T <: AbstractFloat} end
-
-Base.:(+)(c1::Component{T}, c2::Component{T}) where T = Sum{T}([c1, c2], reduce(hcat, [c1.H, c2.H]))
+abstract type AbstractComponent{T <: AbstractFloat} end
 
 """
     simulate(sts::Component, steps, x₀, P₀, σ; compound_uncertainty = true)

--- a/src/components/gaussian_linear.jl
+++ b/src/components/gaussian_linear.jl
@@ -6,14 +6,14 @@ Gausssian linear state space model with observation matrix $H$,
 transition matrix $F$ and transition covariance matrix $Q$.
 
 """
-struct GaussianLinear{T, M, N} <: Component{T}
-    H::SMatrix{M, N, T}
-    F::SMatrix{N, N, T}
-    Q::SMatrix{N, N, T}
+struct GaussianLinear{T, U <: AbstractMatrix{T}, V <: AbstractMatrix{T}} <: AbstractComponent{T}
+    H::U
+    F::V
+    Q::V
 end
 
 observation_matrix(c::GaussianLinear) = c.H
-latent_size(c::GaussianLinear{T, M, N}) where  {T, M, N} = N
+latent_size(c::GaussianLinear) = size(c.H, 2)
 num_params(c::GaussianLinear) = 0
 Base.:(==)(c1::GaussianLinear, c2::GaussianLinear) = all([
     c1.H == c2.H,
@@ -28,7 +28,7 @@ Base.:(==)(c1::GaussianLinear, c2::GaussianLinear) = all([
 Deterministic observation of state $x$.
 
 """
-function observe(c::GaussianLinear, x)
+function observe(c::GaussianLinear{T}, x) where {T}
     (;H) = c
     return H*x
 end
@@ -40,7 +40,7 @@ end
 Probabilistic observation of state with mean $x$, covariance $P$ and observation noise covariance $R$.
 
 """
-function observe(c::GaussianLinear, x, P, R)
+function observe(c::GaussianLinear{T}, x, P, R) where {T}
     (;H) = c
     y = H*x
     S = H*P*H' + R
@@ -54,11 +54,11 @@ end
 Deterministic transition of state $x$.
 
 """
-function transition(c::GaussianLinear, x)
+function transition(c::GaussianLinear{T}, x) where {T}
     (;F) = c
     return F*x
 end
-transition(c::GaussianLinear, x, t::Integer) = transition(c, x)
+transition(c::GaussianLinear{T}, x, t::V) where {T, V <: Integer} = transition(c, x)
 
 @doc raw"""
 
@@ -67,10 +67,10 @@ transition(c::GaussianLinear, x, t::Integer) = transition(c, x)
 Probabilistic transition of state with mean $x$ and covariance $P$.
 
 """
-function transition(c::GaussianLinear, x, P)
+function transition(c::GaussianLinear{T}, x, P) where {T}
     (;F, Q) = c
     x = F*x
     P = F*P*F' + Q
     return x, P
 end
-transition(c::GaussianLinear, x, P, t::Integer) = transition(c, x, P)
+transition(c::GaussianLinear{T}, x, P, t::V) where {T, V <: Integer} = transition(c, x, P)

--- a/src/components/local_level.jl
+++ b/src/components/local_level.jl
@@ -4,5 +4,5 @@
 
 """
 function LocalLevel(level_scale::T) where T
-    GaussianLinear{float(T), 1, 1}([1.;;], [1.;;], diagm([convert(float(T), level_scale)^2]))
+    GaussianLinear(SA[1.;;], SA[1.;;], SA[convert(float(T), level_scale)^2;;])
 end

--- a/src/components/local_linear.jl
+++ b/src/components/local_linear.jl
@@ -4,5 +4,5 @@
 
 """
 function LocalLinear(level_scale::T, slope_scale::U) where {T, U}
-    GaussianLinear{float(T), 1, 2}([1. 0.], [1. 1.; 0. 1.], diagm([convert(float(T), level_scale)^2, convert(float(U), slope_scale)^2]))
+    GaussianLinear(SA[1. 0.], SA[1. 1.; 0. 1.], SA[convert(float(T), level_scale)^2 0; 0 convert(float(U), slope_scale)^2])
 end

--- a/src/components/sum.jl
+++ b/src/components/sum.jl
@@ -1,41 +1,17 @@
-"""
-
-Sum{T(components::Vector{Component{T}})
-
-"""
-struct Sum{T} <: Component{T}
-    components::Vector{Component{T}}
-    H::Matrix{T}
+struct Sum{T, C1 <: AbstractComponent{T}, C2 <: AbstractComponent{T}, X <: AbstractMatrix{T}} <: AbstractComponent{T}
+    component1::C1
+    component2::C2
+    H::X
 end
 
-function Sum(components::Vector{Component{T}}) where T    
-    H = reduce(hcat, [c.H for c in components])
-    return Sum{T}(components, H)
+Base.:(+)(c1::U, c2::V) where {U <: AbstractComponent, V <: AbstractComponent} = begin
+    H = hcat(observation_matrix(c1), observation_matrix(c2))
+    Sum(c1, c2, H)
 end
 
 observation_matrix(c::Sum) = c.H
-latent_size(m::Sum) = reduce(+, latent_size.(m.components))
-num_params(m::Sum) = reduce(+, num_params.(m.components))
-Base.length(m::Sum) = length(m.components)
-Base.:(==)(c1::Sum, c2::Sum) = all(c1.components .== c2.components)
-
-function _make_indices(sizes)
-    collect(zip(vcat(0, sizes) .+ 1, cumsum(sizes)))
-end
-
-"""Chunks a vector into components which sizes are determined by `sizes`."""
-function _chunk(x::T, sizes) where T <: AbstractVector
-    indices = _make_indices(sizes)
-    chunks = [SVector{j-i+1}(x[i:j]) for (i, j) in indices]
-    return chunks
-end
-
-"""Chunks a matrix into block matrix components"""
-function _chunk(x::T, sizes) where T <: AbstractMatrix
-    indices = _make_indices(sizes)
-    chunks = [SMatrix{j-i+1, j-i+1}(x[i:j, i:j]) for (i, j) in indices]
-    return chunks
-end
+latent_size(c::Sum) = latent_size(c.component1) + latent_size(c.component2)
+num_params(c::Sum) = num_pa(c.component1) + num_params(c.component2)
 
 @doc raw"""
 
@@ -44,7 +20,7 @@ end
 Deterministic observation of state $x$.
 
 """
-function observe(c::Sum{T}, x::Vector{T}) where T
+function observe(c::Sum{U, T}, x) where {U, T}
     (;H) = c
     return H*x
 end
@@ -56,7 +32,7 @@ end
 Probabilistic observation of state with mean $x$, covariance $P$ and observation noise covariance $R$.
 
 """
-function observe(c::Sum{T}, x, P, R) where T
+function observe(c::Sum{U, T}, x, P, R) where {U, T}
     (;H) = c
     y = H*x
     S = H*P*H' + R
@@ -71,10 +47,14 @@ Deterministic transition of state $x$ for time step $t$.
 The time step parameter $t$ is forwarded to time dependent components.
 
 """
-function transition(c::Sum{T}, x, t) where T
-    sizes = latent_size.(c.components)
-    xs = _chunk(x, sizes)
-    x = reduce(vcat, transition.(c.components, xs, Ref(t)))
+function transition(c::Sum{U, T}, x, t) where {U, T}
+    size1 = latent_size(c.component1)
+
+    x1 = @view x[begin:size1]
+    x2 = @view x[size1+1:end]
+    x1 = transition(c.component1, x1, t)
+    x2 = transition(c.component2, x2, t)    
+    x = vcat(x1, x2)
     return x
 end
 
@@ -86,12 +66,17 @@ Probabilistic transition of state with mean $x$ and covariance $P$ for time step
 The time step parameter $t$ is forwarded to time dependent components.
 
 """
-function transition(c::Sum{T}, x, P, t) where T
-    sizes = latent_size.(c.components)
-    xs = _chunk(x, sizes)
-    Ps = _chunk(P, sizes)
-    results = reduce(vcat, transition.(c.components, xs, Ps, Ref(t)))
-    x = reduce(vcat, [r[1] for r in results])
-    P = blockdiagonal([r[2] for r in results])
+function transition(c::Sum{U, T}, x, P, t) where {U, T}
+    size1 = latent_size(c.component1)
+    
+    x1 = @view x[begin:size1]
+    x2 = @view x[size1+1:end]
+    P1 = @view P[begin:size1,begin:size1]
+    P2 = @view P[size1+1:end,size1+1:end]
+    
+    x1, P1 = transition(c.component1, x1, P1, t)
+    x2, P2 = transition(c.component2, x2, P2, t)    
+    x = vcat(x1, x2)
+    P = blockdiagonal(P1, P2)
     return x, P
 end

--- a/src/components/utils.jl
+++ b/src/components/utils.jl
@@ -1,33 +1,29 @@
-"""
-    blockdiagonal(mats::Vector{AbstractMatrix{T}})
-
-Constructs a block diagonal matrix from `mats`.
-"""
-function blockdiagonal(mats::Vector{AbstractMatrix{T}}) where T
-    M, N = mapreduce(size, .+, mats)
-    res = zeros(T, M, N)
-    cur_ind = CartesianIndex(0, 0)
-    for m in mats
-        m_inds = CartesianIndices(m)
-        for i in m_inds
-            res[i + cur_ind] = m[i]
-        end
-        cur_ind += m_inds[end]
+function _block_copy!(res, m1, m2)
+    for i in CartesianIndices(m1)
+        res[i] = m1[i]
     end
+
+    size1 = CartesianIndex(size(m1)...)
+    for i in CartesianIndices(m2)
+        res[i + size1] = m2[i]
+    end
+end    
+
+function blockdiagonal(m1::U, m2::V) where {T, U <:AbstractMatrix{T}, V <: AbstractMatrix{T}}
+    M, N = size(m1) .+ size(m2)
+    res = zeros(T, M, N)
+    _block_copy!(res, m1, m2)
     res
 end
 
-function blockdiagonal(mats)
-    M, N = mapreduce(size, .+, mats)
-    T = eltype(first(mats))
-    res = zeros(T, M, N)
-    cur_ind = CartesianIndex(0, 0)
-    for m in mats
-        m_inds = CartesianIndices(m)
-        for i in m_inds
-            res[i + cur_ind] = m[i]
-        end
-        cur_ind += m_inds[end]
-    end
-    res
+
+function blockdiagonal(m1::U, m2::V) where {M1, M2, N1, N2, T, U <:StaticMatrix{M1, N1, T}, V <: StaticMatrix{M2, N2, T}}
+    M, N = M1+M2, N1+N2
+    res = @MMatrix zeros(T, M, N)
+    _block_copy!(res, m1, m2)
+    SizedMatrix{M, N, T}(res)
+end
+
+function blockdiagonal(mats::T) where T <: AbstractVector{Diagonal} 
+    Diagonal(mapreduce(diag, vcat, mats))
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/components/sum.jl
+++ b/test/components/sum.jl
@@ -5,27 +5,27 @@
         c₂ = LocalLevel(1)
         m = c₁ + c₂
 
-        @test m.components[1] == c₁
-        @test m.components[2] == c₂
+        @test m.component1 == c₁
+        @test m.component2 == c₂
     end
 
     @testset "transition probabilistic" begin
-        m = LocalLevel(1) + Seasonal(2, 1, 1)
-        x = [1., 2., 0.]
+        m = LocalLevel(1) + Seasonal(3, 1, 1)
+        x = [1., 1., 2., 0.]
         P = diagm(ones(length(x)))
         R = [0.1;;]
         x₁, P₁ = transition(m, x, P, 1)
         y₁, S = observe(m, x₁, P₁, R)
         
-        @test P₁ == Float64[2 0 0; 0 1 0; 0 0 1]
+        @test P₁ == Float64[2 0 0 0; 0 1 0 0 ; 0 0 1 0; 0 0 0 1]
         @test only(y₁) == x₁[1] + x₁[2] # observe level plus season effect
         @test x₁ == x # constant state        
         @test S == [3.1;;]
     end
 
     @testset "transition deterministic" begin
-        m = LocalLevel(1) + Seasonal(2, 1, 1)
-        x = [1., 2., 0.]
+        m = LocalLevel(1) + Seasonal(3, 1, 1)
+        x = [1., 1., 2., 0.]
         x₁ = transition(m, x, 1)
         y₁ = observe(m, x₁)
         @test only(y₁) == x₁[1] + x₁[2] # observe level plus season effect
@@ -45,13 +45,37 @@
     
     @testset "size" begin
         num_seasons = 5
-        m = LocalLinear(1., 1.) + Seasonal(num_seasons, 2, 1)
-        @test latent_size(m) == num_seasons + 2
+        c1 = LocalLinear(1., 1.)
+        c2 = Seasonal(num_seasons, 2, 1)
+        m = c1 + c2
+        @test latent_size(m) == latent_size(c1) + latent_size(c2)
     end
         
     @testset "observation matrix" begin
         m = LocalLevel(1.) + Seasonal(3, 1, 1)
         H = observation_matrix(m)
         @test H == [1. 1. 0. 0.]
+    end
+    
+    @testset "nested sums" begin
+        m1 = LocalLevel(1.) + Seasonal(3, 1, 1)
+        m2 = LocalLinear(1., 2.)
+        m = m1 + m2
+
+        H = observation_matrix(m)
+        @test H == [1. 1. 0. 0. 1. 0]
+        
+        x = [1., 2., 0., 0., 1., 1.]
+        P = diagm(ones(length(x)))
+        x₁ = transition(m, x, 1)
+        y₁ = observe(m, x₁)
+        @test only(y₁) == x₁[1] + x₁[2] + x₁[5]
+
+        R = [0.1;;]
+        x₁, P₁ = transition(m, x, P, 1)
+        y₁, S₁ = observe(m, x₁, P, R)
+        @test S₁ == [3.1;;]
+        @test P₁ == Float64[2 0 0 0 0 0; 0 1 0 0 0 0; 0 0 1 0 0 0; 0 0 0 1 0 0; 0 0 0 0 3 1; 0 0 0 0 1 5]
+        @test only(y₁) == x₁[1] + x₁[2] + x₁[5]
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using STSlib
 using Test
 using LinearAlgebra
+using StaticArrays
 
 include("components/component.jl")
 include("components/seasonal.jl")


### PR DESCRIPTION
Moves all the internal component stuff to static arrays and implements sum as a binary combination. This way we can always keep track on the types of the added components. This way we completely remove allocations.